### PR TITLE
Exclude nodeValue instanceof RegExp.

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -128,7 +128,7 @@
           visitPre(ast, function(node){
             var nodeValue;
             nodeValue = getPath(node, name);
-            if ('object' === typeof nodeValue && isMatchComplex(nodeValue, op, value, sel) || isMatchPrimitiveLiteral(nodeValue, op, value, valueType)) {
+            if ('object' === typeof nodeValue && not$(nodeValue instanceof RegExp) && isMatchComplex(nodeValue, op, value, sel) || isMatchPrimitiveLiteral(nodeValue, op, value, valueType)) {
               matches.push(node);
               if (isSubject) {
                 subject.push([node]);
@@ -510,6 +510,7 @@
     finalMatches: finalMatches,
     matchAst: matchAst
   };
+  function not$(x){ return !x; }
   function in$(x, xs){
     var i = -1, l = xs.length >>> 0;
     while (++i < l) if (x === xs[i]) return true;

--- a/src/match.ls
+++ b/src/match.ls
@@ -89,7 +89,7 @@ function match-ast ast, selector, cache
         sel = sel-val.sel
         visit-pre ast, (node) !->
           node-value = get-path node, name
-          if 'object' is typeof node-value and is-match-complex node-value, op, value, sel
+          if 'object' is typeof node-value and (not) node-value instanceof RegExp and is-match-complex node-value, op, value, sel
           or is-match-primitive-literal node-value, op, value, value-type
             matches.push node
             if is-subject


### PR DESCRIPTION
``` js:fuga.js
(function () {
  var grasp = require('grasp');
  var replacer = grasp.replace('squery', 'literal[val=hoge]', 'fuga');
  console.log(replacer('var a = "hoge";').toString());// var a = fuga;
  console.log(replacer('var a = "hoge";var b = /a/;').toString());// var a = fuga;var b = /a/;
})();
```

``` sh
$ node fuga.js 
var a = fuga;

/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:37
    ref$ = syntaxFlat[ast.type], nodes = ref$.nodes, nodeArrays = ref$.nodeArr
                                             ^
TypeError: Cannot read property 'nodes' of undefined
    at visitPre (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:37:46)
    at new Cache (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:10:5)
    at isMatchComplex (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/match.js:495:13)
    at /Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/match.js:131:50
    at visitPre (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:36:5)
    at visitPre (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:46:9)
    at visitPre (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:56:11)
    at visitPre (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/common.js:56:11)
    at matchAst (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/match.js:128:11)
    at matchAst (/Users/monjudoh/temp/grasp/node_modules/grasp/node_modules/grasp-squery/lib/match.js:318:32)
```
