### PR TITLE
Fix crash on object spread nodes

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -13,14 +13,16 @@
       if (type === 'ObjectExpression') {
         for (i$ = 0, len$ = (ref$ = node.properties).length; i$ < len$; ++i$) {
           property = ref$[i$];
-          property.type = 'Property';
-          property.start = property.key.start;
-          property.end = property.value.end;
-          if (property.key.loc) {
-            property.loc = {
-              start: property.key.loc.start,
-              end: property.value.loc.end
-            };
+          if (property.key) {
+            property.type = 'Property';
+            property.start = property.key.start;
+            property.end = property.value.end;
+            if (property.key.loc) {
+              property.loc = {
+                start: property.key.loc.start,
+                end: property.value.loc.end
+              };
+            }
           }
         }
       }

--- a/src/common.ls
+++ b/src/common.ls
@@ -6,14 +6,15 @@
   visit-pre ast, ({type}:node) !->
     if type is 'ObjectExpression'
       for property in node.properties
-        property <<<
-          type: 'Property'
-          start: property.key.start
-          end: property.value.end
-        if property.key.loc
-          property.loc =
-            start: property.key.loc.start
-            end: property.value.loc.end
+        if property.key
+          property <<<
+            type: 'Property'
+            start: property.key.start
+            end: property.value.end
+          if property.key.loc
+            property.loc =
+              start: property.key.loc.start
+              end: property.value.loc.end
     nodes.push node
     types[type] ?= []
     types[type].push node


### PR DESCRIPTION
With object spread, the property node doesn't have a key, just an identifier so keep the normal start/end values. I'm not 100% sure that there won't be other side effects as I'm new to this codebase, but this should address #5. Please let me know if there's a better way to fix this and I'll refactor.